### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP server provides access to Siri shortcuts functionality via the Model Context Protocol (MCP). It allows listing, opening, and running shortcuts from the macOS Shortcuts app.
 
+<a href="https://glama.ai/mcp/servers/ijrlb9sj4k">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ijrlb9sj4k/badge" alt="Siri Shortcuts Server MCP server" />
+</a>
+
 ![screenshot](./screenshot.png)
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Siri Shortcuts MCP Server](https://glama.ai/mcp/servers/ijrlb9sj4k) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ijrlb9sj4k">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ijrlb9sj4k/badge" alt="Siri Shortcuts Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.